### PR TITLE
feat: Add retry logic for RateLimit errors with configurable maxRetries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ fetch-notion-page <page-url>
 
 # Or fetch a page as Markdown
 fetch-notion-page <page-url> --format markdown
+
+# Specify maximum retries for rate limit errors
+fetch-notion-page <page-url> --max-retries 3
 ```
 
 ### Programmatic Usage
@@ -43,7 +46,8 @@ import { fetchNotionPage, convertPageToMarkdown } from 'fetch-notion-page';
 // Fetch a Notion page with all its child blocks
 const result = await fetchNotionPage('your-page-id', {
   apiKey: 'your-api-key',
-  maxDepth: 10 // Optional: limit recursion depth
+  maxDepth: 10, // Optional: limit recursion depth
+  maxRetries: 3 // Optional: maximum retries for rate limit errors (default: 3)
 });
 
 if (result.type === 'Success') {
@@ -68,6 +72,7 @@ Recursively fetches a Notion page and all its child blocks.
 - `options` (object):
   - `apiKey` (string): Your Notion integration API key
   - `maxDepth` (number, optional): Maximum recursion depth (default: 10)
+  - `maxRetries` (number, optional): Maximum number of retries for rate limit errors (default: 3)
 
 **Returns:**
 - `Result<PageWithChildren, FetchNotionPageError>`: A result object containing either the page data or error information

--- a/src/libs/notion-block-fetcher.ts
+++ b/src/libs/notion-block-fetcher.ts
@@ -2,10 +2,13 @@ import type { Client } from "@notionhq/client";
 import type { BlockObjectResponse } from "@notionhq/client/build/src/api-endpoints.js";
 import { Result } from "@praha/byethrow";
 import type { NotionApiError } from "../types/index.js";
-import { retryOnRateLimit } from "./retry-utils.js";
+import { retryOnRateLimit, type RetryOptions } from "./retry-utils.js";
 
 export class NotionBlockFetcher {
-  constructor(private readonly client: Client) {}
+  constructor(
+    private readonly client: Client,
+    private retryOptions?: RetryOptions,
+  ) {}
 
   async fetchBlocks(
     blockId: string,
@@ -30,7 +33,7 @@ export class NotionBlockFetcher {
 
           const response = await retryOnRateLimit(async () => {
             return await this.client.blocks.children.list(params);
-          });
+          }, this.retryOptions);
 
           blocks.push(...(response.results as BlockObjectResponse[]));
           cursor = response.next_cursor ?? undefined;

--- a/src/libs/notion-block-fetcher.ts
+++ b/src/libs/notion-block-fetcher.ts
@@ -2,7 +2,7 @@ import type { Client } from "@notionhq/client";
 import type { BlockObjectResponse } from "@notionhq/client/build/src/api-endpoints.js";
 import { Result } from "@praha/byethrow";
 import type { NotionApiError } from "../types/index.js";
-import { retryOnRateLimit, type RetryOptions } from "./retry-utils.js";
+import { type RetryOptions, retryOnRateLimit } from "./retry-utils.js";
 
 export class NotionBlockFetcher {
   constructor(

--- a/src/libs/notion-page-fetcher.ts
+++ b/src/libs/notion-page-fetcher.ts
@@ -2,7 +2,7 @@ import type { Client } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints.js";
 import { Result } from "@praha/byethrow";
 import type { NotionApiError } from "../types/index.js";
-import { retryOnRateLimit, type RetryOptions } from "./retry-utils.js";
+import { type RetryOptions, retryOnRateLimit } from "./retry-utils.js";
 
 export class NotionPageFetcher {
   constructor(

--- a/src/libs/notion-page-fetcher.ts
+++ b/src/libs/notion-page-fetcher.ts
@@ -2,10 +2,13 @@ import type { Client } from "@notionhq/client";
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints.js";
 import { Result } from "@praha/byethrow";
 import type { NotionApiError } from "../types/index.js";
-import { retryOnRateLimit } from "./retry-utils.js";
+import { retryOnRateLimit, type RetryOptions } from "./retry-utils.js";
 
 export class NotionPageFetcher {
-  constructor(private client: Client) {}
+  constructor(
+    private client: Client,
+    private retryOptions?: RetryOptions,
+  ) {}
 
   async fetchPage(
     pageId: string,
@@ -14,7 +17,7 @@ export class NotionPageFetcher {
       try: async (): Promise<PageObjectResponse> => {
         const response = await retryOnRateLimit(async () => {
           return await this.client.pages.retrieve({ page_id: pageId });
-        });
+        }, this.retryOptions);
         return response as PageObjectResponse;
       },
       catch: (error: unknown): NotionApiError => this.handleError(error),

--- a/src/libs/retry-utils.test.ts
+++ b/src/libs/retry-utils.test.ts
@@ -1,7 +1,4 @@
-import {
-  APIErrorCode,
-  APIResponseError,
-} from "@notionhq/client";
+import { APIErrorCode, APIResponseError } from "@notionhq/client";
 import { describe, expect, test, vi } from "vitest";
 import { retryOnRateLimit } from "./retry-utils.js";
 
@@ -12,7 +9,8 @@ function createRateLimitError(
   retryAfter?: string,
   headers?: Record<string, string> | Headers,
 ): APIResponseError {
-  const errorHeaders = headers || (retryAfter ? { "retry-after": retryAfter } : {});
+  const errorHeaders =
+    headers || (retryAfter ? { "retry-after": retryAfter } : {});
   return new APIResponseError({
     code: APIErrorCode.RateLimited,
     status: 429,
@@ -51,9 +49,9 @@ describe("retryOnRateLimit", () => {
 
     const fn = vi.fn().mockRejectedValue(rateLimitError);
 
-    await expect(
-      retryOnRateLimit(fn, { maxRetries: 2 }),
-    ).rejects.toThrow("Rate limited");
+    await expect(retryOnRateLimit(fn, { maxRetries: 2 })).rejects.toThrow(
+      "Rate limited",
+    );
     expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
   });
 

--- a/src/libs/retry-utils.test.ts
+++ b/src/libs/retry-utils.test.ts
@@ -1,0 +1,151 @@
+import {
+  APIErrorCode,
+  APIResponseError,
+} from "@notionhq/client";
+import { describe, expect, test, vi } from "vitest";
+import { retryOnRateLimit } from "./retry-utils.js";
+
+/**
+ * Helper function to create a mock APIResponseError for testing
+ */
+function createRateLimitError(
+  retryAfter?: string,
+  headers?: Record<string, string> | Headers,
+): APIResponseError {
+  const errorHeaders = headers || (retryAfter ? { "retry-after": retryAfter } : {});
+  return new APIResponseError({
+    code: APIErrorCode.RateLimited,
+    status: 429,
+    message: "Rate limited",
+    headers: errorHeaders as any,
+    rawBodyText: JSON.stringify({ code: "rate_limited" }),
+  });
+}
+
+describe("retryOnRateLimit", () => {
+  test("succeeds on first attempt", async () => {
+    const fn = vi.fn().mockResolvedValue("success");
+
+    const result = await retryOnRateLimit(fn);
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries on rate limit error and succeeds", async () => {
+    const rateLimitError = createRateLimitError("0.01");
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce("success");
+
+    const result = await retryOnRateLimit(fn);
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries up to maxRetries times", async () => {
+    const rateLimitError = createRateLimitError("0.01");
+
+    const fn = vi.fn().mockRejectedValue(rateLimitError);
+
+    await expect(
+      retryOnRateLimit(fn, { maxRetries: 2 }),
+    ).rejects.toThrow("Rate limited");
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  test("uses Retry-After header value for wait time", async () => {
+    const rateLimitError = createRateLimitError("0.01");
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce("success");
+
+    const result = await retryOnRateLimit(fn);
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("uses defaultRetryDelay when Retry-After header is missing", async () => {
+    const rateLimitError = createRateLimitError(undefined, {});
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce("success");
+
+    const result = await retryOnRateLimit(fn, { defaultRetryDelay: 0.01 });
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws non-rate-limit errors immediately", async () => {
+    const otherError = new APIResponseError({
+      code: APIErrorCode.ObjectNotFound,
+      status: 404,
+      message: "Other error",
+      headers: {},
+      rawBodyText: JSON.stringify({ code: "object_not_found" }),
+    });
+
+    const fn = vi.fn().mockRejectedValue(otherError);
+
+    await expect(retryOnRateLimit(fn)).rejects.toThrow("Other error");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles Headers object (browser Headers API)", async () => {
+    const headers = new Headers();
+    headers.set("retry-after", "0.01"); // Use a very short delay for testing
+    const rateLimitError = createRateLimitError(undefined, headers);
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce("success");
+
+    const result = await retryOnRateLimit(fn);
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("handles case-insensitive Retry-After header", async () => {
+    const rateLimitError = createRateLimitError(undefined, {
+      "Retry-After": "0.01", // Use a very short delay for testing
+    });
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce("success");
+
+    const result = await retryOnRateLimit(fn);
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("handles invalid Retry-After header value", async () => {
+    const rateLimitError = createRateLimitError(undefined, {
+      "retry-after": "invalid",
+    });
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce("success");
+
+    // Should use defaultRetryDelay when header value is invalid
+    const result = await retryOnRateLimit(fn, { defaultRetryDelay: 0.01 });
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/libs/retry-utils.ts
+++ b/src/libs/retry-utils.ts
@@ -1,0 +1,109 @@
+import {
+  APIErrorCode,
+  APIResponseError,
+  isNotionClientError,
+} from "@notionhq/client";
+
+/**
+ * Extracts the wait time (in seconds) from the Retry-After header
+ */
+function getRetryAfterSeconds(error: unknown): number | null {
+  if (!isNotionClientError(error)) {
+    return null;
+  }
+
+  // APIResponseError has headers property
+  if (APIResponseError.isAPIResponseError(error)) {
+    const headers = error.headers;
+    if (headers) {
+      let retryAfter: string | null = null;
+
+      // If headers is a Headers object (browser Headers API)
+      if (headers instanceof Headers) {
+        retryAfter = headers.get("retry-after");
+      }
+      // If headers is a plain object
+      else if (typeof headers === "object") {
+        const headerObj = headers as Record<string, string>;
+        retryAfter =
+          headerObj["retry-after"] ||
+          headerObj["Retry-After"] ||
+          headerObj["RETRY-AFTER"] ||
+          null;
+      }
+
+      if (retryAfter) {
+        const seconds = Number.parseInt(retryAfter, 10);
+        if (!Number.isNaN(seconds) && seconds > 0) {
+          return seconds;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Waits for the specified number of seconds
+ */
+function sleep(seconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, seconds * 1000);
+  });
+}
+
+/**
+ * Checks if the error is a RateLimit error
+ */
+function isRateLimitError(error: unknown): boolean {
+  if (!isNotionClientError(error)) {
+    return false;
+  }
+
+  return (
+    APIResponseError.isAPIResponseError(error) &&
+    error.code === APIErrorCode.RateLimited
+  );
+}
+
+export interface RetryOptions {
+  /** Maximum number of retries (default: 3) */
+  maxRetries?: number;
+  /** Default wait time in seconds when Retry-After header is not present (default: 1) */
+  defaultRetryDelay?: number;
+}
+
+/**
+ * Retries the function when a RateLimit error occurs
+ */
+export async function retryOnRateLimit<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { maxRetries = 3, defaultRetryDelay = 1 } = options;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      // If it's not a RateLimit error or max retries reached, throw the error
+      if (!isRateLimitError(error) || attempt >= maxRetries) {
+        throw error;
+      }
+
+      // Get wait time from Retry-After header
+      const retryAfterSeconds = getRetryAfterSeconds(error);
+      const waitSeconds = retryAfterSeconds ?? defaultRetryDelay;
+
+      // Wait before retrying
+      await sleep(waitSeconds);
+    }
+  }
+
+  // This line should never be reached, but needed for TypeScript type checking
+  throw lastError;
+}

--- a/src/usecase/fetch-notion-page.ts
+++ b/src/usecase/fetch-notion-page.ts
@@ -13,6 +13,7 @@ import type {
 type FetchNotionPageOptions = {
   apiKey: string;
   maxDepth?: number;
+  maxRetries?: number;
   client?: Client; // テスト用のクライアント注入
 };
 
@@ -47,8 +48,12 @@ export async function fetchNotionPage(
     try: async () => {
       const client =
         options.client || new NotionClient({ auth: options.apiKey });
-      const blockFetcher = new NotionBlockFetcher(client);
-      const pageFetcher = new NotionPageFetcher(client);
+      const retryOptions =
+        options.maxRetries !== undefined
+          ? { maxRetries: options.maxRetries }
+          : undefined;
+      const blockFetcher = new NotionBlockFetcher(client, retryOptions);
+      const pageFetcher = new NotionPageFetcher(client, retryOptions);
 
       // ページ情報を取得
       const pageResult = await pageFetcher.fetchPage(pageId);


### PR DESCRIPTION
## Summary

Fix https://github.com/yukukotani/fetch-notion-page/issues/1

This PR adds automatic retry logic for RateLimit errors when calling the Notion API, with support for configurable maximum retry attempts.

## Changes

- ✅ Added  with  function that:
  - Automatically retries on RateLimit errors (HTTP 429)
  - Respects  header from Notion API responses
  - Uses type-safe error handling with  and 
  - Supports configurable  and  options

- ✅ Integrated retry logic into  and 
- ✅ Added  option to  function for library usage
- ✅ Added  CLI option for command-line usage
- ✅ Added comprehensive test coverage for retry functionality
- ✅ Updated README with documentation for the new  option

## Features

- **Automatic retry**: RateLimit errors are automatically retried up to the configured maximum
- **Retry-After support**: Waits for the time specified in the  header
- **Type-safe**: Uses Notion SDK's  and  for proper error handling
- **Configurable**: Both library and CLI users can specify  (default: 3)

## Testing

All existing tests pass, and new tests have been added for:
- Successful retry scenarios
- Maximum retry limit enforcement
- Retry-After header handling
- Default delay fallback
- Error handling for non-rate-limit errors

## Related

Implements retry logic as recommended in the [Notion API documentation](https://developers.notion.com/reference/request-limits).