### PR TITLE
Add GitHub Actions workflows for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Cache Bun dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+
+    - name: Install dependencies
+      run: bun install --frozen-lockfile
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Run tests
+      run: bun run test
+
+    - name: Publish to npm
+      run: bun publish --access public
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get version from tag
+      id: tag_version
+      run: |
+        TAG_NAME=${GITHUB_REF#refs/tags/}
+        VERSION=${TAG_NAME#v}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+
+    - name: Verify package.json version matches tag
+      run: |
+        PACKAGE_VERSION=$(node -p "require('./package.json').version")
+        TAG_VERSION="${{ steps.tag_version.outputs.version }}"
+        if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+          echo "Error: package.json version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
+          exit 1
+        fi
+
+    - name: Generate release notes
+      id: release_notes
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { data: tags } = await github.rest.repos.listTags({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const currentTag = '${{ steps.tag_version.outputs.tag }}';
+          const currentIndex = tags.findIndex(t => t.name === currentTag);
+          const previousTag = currentIndex < tags.length - 1 ? tags[currentIndex + 1].name : '';
+
+          let changes = '';
+          if (previousTag) {
+            const { data: commits } = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: previousTag,
+              head: currentTag,
+            });
+
+            changes = commits.commits
+              .filter(commit => !commit.commit.message.match(/^chore|^ci|^docs|^style|^refactor|^test/i))
+              .map(commit => `- ${commit.commit.message.split('\n')[0]} (${commit.sha.substring(0, 7)})`)
+              .join('\n') || '- No significant changes';
+          } else {
+            changes = '- Initial release';
+          }
+
+          core.setOutput('body', changes);
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.tag_version.outputs.tag }}
+        name: Release ${{ steps.tag_version.outputs.tag }}
+        body: |
+          ## Changes
+
+          ${{ steps.release_notes.outputs.body }}
+
+          ## Installation
+
+          ```bash
+          npm install fetch-notion-page@${{ steps.tag_version.outputs.version }}
+          ```
+        draft: false
+        prerelease: false
+

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,8 @@
   "ignore": [
     "dist/**",
     "node_modules/**",
-    "coverage/**"
+    "coverage/**",
+    ".github/**"
   ],
   "ignoreDependencies": [],
   "vitest": {


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions workflows for automated npm package publishing using trusted publishing (OIDC).

## Changes

- **release.yml**: Automatically creates a GitHub release when a tag matching `v*` pattern is pushed
  - Validates that package.json version matches the tag version
  - Generates release notes from commits since the previous tag
  - Creates a GitHub release with installation instructions

- **publish.yml**: Publishes the package to npm when a GitHub release is created
  - Uses npm trusted publishing (OIDC) for tokenless authentication
  - Runs tests before publishing
  - Uses `bun publish` to publish the package

## Workflow

1. Update version in `package.json`
2. Commit and push changes
3. Create and push a tag (e.g., `git tag v0.1.2 && git push origin v0.1.2`)
4. The release workflow automatically creates a GitHub release
5. The publish workflow automatically publishes to npm

## Setup Required

After merging this PR, you need to configure trusted publishing on npmjs.com:
1. Go to the package settings page on npmjs.com
2. Navigate to "Trusted Publisher" section
3. Configure:
   - **Organization or user**: `yukukotani`
   - **Repository**: `fetch-notion-page`
   - **Workflow filename**: `publish.yml`

## References

- [npm Trusted Publishing documentation](https://docs.npmjs.com/generating-provenance-statements)
- [npm Trusted Publishing with OIDC](https://efcl.info/2025/09/07/npm-oidc/)