### PR TITLE
Update release workflow to use workflow_dispatch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,16 @@
 name: Create Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type to bump'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 permissions:
   contents: write
@@ -16,23 +23,39 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get version from tag
-      id: tag_version
-      run: |
-        TAG_NAME=${GITHUB_REF#refs/tags/}
-        VERSION=${TAG_NAME#v}
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
 
-    - name: Verify package.json version matches tag
+    - name: Configure git
       run: |
-        PACKAGE_VERSION=$(node -p "require('./package.json').version")
-        TAG_VERSION="${{ steps.tag_version.outputs.version }}"
-        if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-          echo "Error: package.json version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
-          exit 1
-        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Bump version
+      id: bump_version
+      run: |
+        VERSION_TYPE="${{ github.event.inputs.version_type }}"
+        NEW_VERSION=$(npm version $VERSION_TYPE -m "chore(release): %s")
+        NEW_VERSION=${NEW_VERSION#v}
+        echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
+        echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "New version: $NEW_VERSION"
+
+    - name: Push changes and tag
+      run: |
+        git push origin HEAD
+        git push origin v${{ env.VERSION }}
+
+    - name: Set version variables
+      id: version
+      run: |
+        echo "version=${{ steps.bump_version.outputs.version }}" >> $GITHUB_OUTPUT
+        echo "tag=${{ steps.bump_version.outputs.tag }}" >> $GITHUB_OUTPUT
 
     - name: Generate release notes
       id: release_notes
@@ -43,7 +66,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
           });
-          const currentTag = '${{ steps.tag_version.outputs.tag }}';
+          const currentTag = '${{ steps.version.outputs.tag }}';
           const currentIndex = tags.findIndex(t => t.name === currentTag);
           const previousTag = currentIndex < tags.length - 1 ? tags[currentIndex + 1].name : '';
 
@@ -53,7 +76,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               base: previousTag,
-              head: currentTag,
+              head: 'HEAD',
             });
 
             changes = commits.commits
@@ -69,8 +92,8 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ steps.tag_version.outputs.tag }}
-        name: Release ${{ steps.tag_version.outputs.tag }}
+        tag_name: ${{ steps.version.outputs.tag }}
+        name: Release ${{ steps.version.outputs.tag }}
         body: |
           ## Changes
 
@@ -79,7 +102,7 @@ jobs:
           ## Installation
 
           ```bash
-          npm install fetch-notion-page@${{ steps.tag_version.outputs.version }}
+          npm install fetch-notion-page@${{ steps.version.outputs.version }}
           ```
         draft: false
         prerelease: false


### PR DESCRIPTION
## Summary

This PR updates the release workflow to use `workflow_dispatch` only, removing the push trigger for tags.

## Changes

- Remove push trigger for tags
- Add `workflow_dispatch` with `version_type` input (major/minor/patch)
- Automatically bump version, commit, and create tag when workflow is triggered
- Simplify workflow by removing push event handling

## Usage

After merging, you can create releases by:
1. Going to Actions tab
2. Selecting "Create Release" workflow
3. Clicking "Run workflow"
4. Choosing version type (major/minor/patch)

The workflow will automatically:
- Bump the version in package.json
- Commit the change
- Create and push a tag
- Create a GitHub release
- Trigger the npm publish workflow